### PR TITLE
Update to Django 5

### DIFF
--- a/app/requirements/postgres.txt
+++ b/app/requirements/postgres.txt
@@ -1,9 +1,9 @@
 django-extensions==3.0.9
-Django==4.2.4
+Django==5.1.3
 django-bootstrap-modal-forms==2.0.0
 django-crispy-forms==1.9.2
 django-jsonview==2.0.0
-django-q==1.3.4
+django-q2==1.7.4
 geopy==2.4.1
 gunicorn==20.0.4
 numpy>=1.22.4


### PR DESCRIPTION
Will close #5. To update to Django 5, `django-q` is updated and should be replaced by `django-q2` instead. After running the migrations everything seems to work as expected. To update locally:

``` 
pip install Django==5.1.3
pip uninstall django-q
pip install django-q2
python manage.py migrate django_q
```

I did not have any postgres issues because I am running postgres 16.4. @Bachibouzouk Which version are you using? Apparently Django 5.0 still supports postgress >= 12, so we could downgrade to this if needed. Starting from 5.1, only postgres >= 13 is supported. 