### PR TITLE
change settings to environ, minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@
 **/cdn_static_root/
 .envs/*
 **/venv/
-**/migrations/*.py
 app/.env

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 **/cdn_static_root/
 .envs/*
 **/venv/
+**/migrations/*.py
+app/.env

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Prior to be able to develop locally, you might need to install postgres and crea
 3. Move to the `app` folder with `cd app`
 4. Install the dependencies with `pip install -r requirements/postgres.txt`
 5. Install extra local development dependencies with `pip install -r dev_requirements.txt`
-6. Create environment variables for communication with the database (only replace content surrounded by `<>`)
+6. Create environment variables or a new file in the app directory called `.env` for communication with the database (only replace content surrounded by `<>`)
 ```
 SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=<your db name>

--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -10,23 +10,33 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
-import ast
-import os
+import environ
+from pathlib import Path
+import sys
 
 from django.contrib.messages import constants as messages
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = ast.literal_eval(os.getenv("DEBUG", "False"))
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Root dir is a parent directory
+ROOT_DIR = environ.Path(__file__) - 2
+
+# Read environment variables
+env = environ.Env()
+
+# Read .env file
+# OS environment variables take precedence over variables from .env file
+env.read_env(str(ROOT_DIR.path(".env")))
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = env.bool("DEBUG", default=False)
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
-STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+STATICFILES_DIRS = (str(BASE_DIR / "static"),)
 STATIC_URL = "/static/"
-STATIC_ROOT = os.path.join(BASE_DIR, "cdn_static_root")
-
+STATIC_ROOT = str(BASE_DIR / "cdn_static_root")
 STATICFILES_FINDERS = ["django.contrib.staticfiles.finders.FileSystemFinder"]
 
 if DEBUG is True:
@@ -37,14 +47,12 @@ if DEBUG is True:
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("EPA_SECRET_KEY", "v@p9^=@lc3#1u_xtx*^xhrv0l3li1(+8ik^k@g-_bzmexb0$7n")
-
+SECRET_KEY = env("EPA_SECRET_KEY", default="v@p9^=@lc3#1u_xtx*^xhrv0l3li1(+8ik^k@g-_bzmexb0$7n")
 ALLOWED_HOSTS = ["*"]
-
-CSRF_TRUSTED_ORIGINS = [
-    f"https://{os.getenv('TRUSTED_HOST')}",
-    f"http://{os.getenv('TRUSTED_HOST')}",
-]
+CSRF_TRUSTED_ORIGINS = list()
+if env("TRUSTED_HOST", default=None) is not None:
+    CSRF_TRUSTED_ORIGINS.append(f"https://{env('TRUSTED_HOST')}")
+    CSRF_TRUSTED_ORIGINS.append(f"http://{env('TRUSTED_HOST')}")
 # Application definition
 
 INSTALLED_APPS = [
@@ -94,7 +102,7 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "DIRS": [str(BASE_DIR / "templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -112,23 +120,16 @@ WSGI_APPLICATION = "epa.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-# SQLite is used if no other database system is set via environment variables.
+# SQLite does not support ArrayField, so PostgreSQL is needed as engine
 DATABASES = {
-    "default": (
-        {
-            "ENGINE": os.environ.get("SQL_ENGINE"),
-            "NAME": os.environ.get("SQL_DATABASE"),
-            "USER": os.environ.get("SQL_USER"),
-            "PASSWORD": os.environ.get("SQL_PASSWORD"),
-            "HOST": os.environ.get("SQL_HOST"),
-            "PORT": os.environ.get("SQL_PORT"),
-        }
-        if os.environ.get("SQL_ENGINE")
-        else {
-            "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
-            "NAME": os.environ.get("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
-        }
-    )
+    "default": {
+        "ENGINE": env("SQL_ENGINE", default="django.db.backends.postgresql"),
+        "NAME": env("SQL_DATABASE"),  # required
+        "USER": env("SQL_USER", default=None),
+        "PASSWORD": env("SQL_PASSWORD", default=None),
+        "HOST": env("SQL_HOST", default=None),
+        "PORT": env.int("SQL_PORT", default=5432),
+    }
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
@@ -148,7 +149,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en"
 
-LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
+LOCALE_PATHS = (BASE_DIR / "locale",)
 
 LANGUAGES = [("de", "German"), ("en", "English")]
 
@@ -173,15 +174,15 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 # Please note, we don't use Django's internal email system,
 # we implement our own, using exchangelib
-USE_EXCHANGE_EMAIL_BACKEND = ast.literal_eval(os.getenv("USE_EXCHANGE_EMAIL_BACKEND", "True"))
+USE_EXCHANGE_EMAIL_BACKEND = env.bool("USE_EXCHANGE_EMAIL_BACKEND", default=True)
 # The Exchange account which sends emails
-EXCHANGE_ACCOUNT = os.getenv("EXCHANGE_ACCOUNT", "dummy@dummy.com")
-EXCHANGE_PW = os.getenv("EXCHANGE_PW", "dummypw")
-EXCHANGE_EMAIL = os.getenv("EXCHANGE_EMAIL", "dummy@dummy.com")
-EXCHANGE_SERVER = os.getenv("EXCHANGE_SERVER", "dummy.com")
+EXCHANGE_ACCOUNT = env("EXCHANGE_ACCOUNT", default="dummy@dummy.com")
+EXCHANGE_PW = env("EXCHANGE_PW", default="dummypw")
+EXCHANGE_EMAIL = env("EXCHANGE_EMAIL", default="dummy@dummy.com")
+EXCHANGE_SERVER = env("EXCHANGE_SERVER", default="dummy.com")
 # Email addresses to which feedback emails will be sent
-RECIPIENTS = os.getenv("RECIPIENTS", "dummy@dummy.com,dummy2@dummy.com").split(",")
-EMAIL_SUBJECT_PREFIX = os.getenv("EMAIL_SUBJECT_PREFIX", "[open_plan] ")
+RECIPIENTS = env.list("RECIPIENTS", default=["dummy@dummy.com", "dummy2@dummy.com"])
+EMAIL_SUBJECT_PREFIX = env("EMAIL_SUBJECT_PREFIX", default="[open_plan] ")
 
 MESSAGE_TAGS = {
     messages.DEBUG: "alert-info",
@@ -191,11 +192,11 @@ MESSAGE_TAGS = {
     messages.ERROR: "alert-danger",
 }
 
-USE_PROXY = ast.literal_eval(os.getenv("USE_PROXY", "True"))
-PROXY_ADDRESS_LINK = os.getenv("PROXY_ADDRESS", "http://proxy:port")
+USE_PROXY = env.bool("USE_PROXY", default=True)
+PROXY_ADDRESS_LINK = env("PROXY_ADDRESS", default="http://proxy:port")
 PROXY_CONFIG = ({"http://": PROXY_ADDRESS_LINK, "https://": PROXY_ADDRESS_LINK}) if USE_PROXY else ({})
 
-MVS_API_HOST = os.getenv("MVS_API_HOST", "https://mvs-eland.rl-institut.de")
+MVS_API_HOST = env("MVS_API_HOST", default="https://mvs-eland.rl-institut.de")
 MVS_POST_URL = f"{MVS_API_HOST}/sendjson/"
 MVS_GET_URL = f"{MVS_API_HOST}/check/"
 MVS_LP_FILE_URL = f"{MVS_API_HOST}/get_lp_file/"
@@ -206,17 +207,22 @@ MVS_SA_GET_URL = f"{MVS_API_HOST}/check-sensitivity-analysis/"
 X_FRAME_OPTIONS = "SAMEORIGIN"
 
 # API token to fetch exchange rates
-EXCHANGE_RATES_API_TOKEN = os.getenv("EXCHANGE_RATES_API_TOKEN")
-EXCHANGE_RATES_URL = f"https://v6.exchangerate-api.com/v6/{EXCHANGE_RATES_API_TOKEN}/latest/USD"
+EXCHANGE_RATES_API_TOKEN = env("EXCHANGE_RATES_API_TOKEN", default=None)
+if EXCHANGE_RATES_API_TOKEN is None:
+    EXCHANGE_RATES_URL = None
+else:
+    EXCHANGE_RATES_URL = f"https://v6.exchangerate-api.com/v6/{EXCHANGE_RATES_API_TOKEN}/latest/USD"
 
 # API to connect with KoboToolbox
 KOBO_API_URL = "https://eu.kobotoolbox.org/api/v2"
-KOBO_API_TOKEN = os.getenv("KOBO_API_TOKEN")
+KOBO_API_TOKEN = env("KOBO_API_TOKEN", default=None)
 
 # API to get weather data
-WEATHER_DATA_API_HOST = os.getenv("WEATHER_DATA_API_HOST")
+WEATHER_DATA_API_HOST = env("WEATHER_DATA_API_HOST", default=None)
 
-import sys
+# RenewablesNinja API
+RN_TOKEN = env("RN_API_TOKEN", default=None)
+RN_API_BASE = "https://www.renewables.ninja/api/"
 
 LOGGING = {
     "version": 1,

--- a/app/initial_setup.sh
+++ b/app/initial_setup.sh
@@ -1,6 +1,5 @@
 #!/usr/local/bin/python
 python manage.py compilemessages
-python manage.py makemigrations users projects dashboard && \
 python manage.py migrate && \
 python manage.py loaddata 'fixtures/fixture.json' && \
 python manage.py collectstatic --no-input && \

--- a/app/local_setup.sh
+++ b/app/local_setup.sh
@@ -1,7 +1,6 @@
 #!/usr/local/bin/python
 echo yes | python manage.py collectstatic && \
 python manage.py compilemessages
-python manage.py makemigrations users projects dashboard wefe && \
 python manage.py migrate && \
 python manage.py loaddata 'fixtures/fixture.json' && \
 pre-commit install && \

--- a/app/projects/services.py
+++ b/app/projects/services.py
@@ -40,6 +40,8 @@ from epa.settings import (
     EMAIL_SUBJECT_PREFIX,
     TIME_ZONE,
     USE_EXCHANGE_EMAIL_BACKEND,
+    RN_TOKEN,
+    RN_API_BASE,
 )
 from plotly.offline import plot
 from plotly.graph_objs import Scatter
@@ -50,14 +52,6 @@ from projects.requests import fetch_mvs_simulation_results
 
 logger = logging.getLogger(__name__)
 
-
-# email account which will send the feedback emails
-EXCHANGE_ACCOUNT = os.getenv("EXCHANGE_ACCOUNT", "dummy@dummy.com")
-EXCHANGE_PW = os.getenv("EXCHANGE_PW", "dummypw")
-EXCHANGE_EMAIL = os.getenv("EXCHANGE_EMAIL", "dummy@dummy.com")
-EXCHANGE_SERVER = os.getenv("EXCHANGE_SERVER", "dummy.com")
-# email addresses to which the feedback emails will be sent
-RECIPIENTS = os.getenv("RECIPIENTS", "dummy@dummy.com,dummy2@dummy.com").split(",")
 
 r"""Functions meant to be powered by Django-Q.
 
@@ -269,13 +263,10 @@ def get_selected_scenarios_in_cache(request, proj_id):
 
 
 class RenewablesNinja:
-    token = os.environ["RN_API_TOKEN"]
-    api_base = "https://www.renewables.ninja/api/"
-
     def __init__(self):
         self.s = requests.session()
         # Send token header with each request
-        self.s.headers = {"Authorization": "Token " + self.token}
+        self.s.headers = {"Authorization": "Token " + RN_TOKEN}
         self.data = dict.fromkeys(["pv", "wind"])
 
     def get_pv_data(self, coordinates):
@@ -283,7 +274,7 @@ class RenewablesNinja:
         # Get PV data
         ##
 
-        url = self.api_base + "data/pv"
+        url = RN_API_BASE + "data/pv"
 
         # Panels are assumed to be latitude tilted
         args = {
@@ -312,7 +303,7 @@ class RenewablesNinja:
         # Get Wind data
         ##
 
-        url = self.api_base + "data/wind"
+        url = RN_API_BASE + "data/wind"
 
         args = {
             "lat": coordinates["lat"],

--- a/app/requirements/dev_requirements.txt
+++ b/app/requirements/dev_requirements.txt
@@ -2,3 +2,4 @@ black==24.8.0
 click==8.0.3
 django-sass-processor
 pre-commit
+libsass

--- a/app/requirements/postgres.txt
+++ b/app/requirements/postgres.txt
@@ -4,6 +4,7 @@ Django==5.1.3
 crispy-bootstrap5
 django-jsonview
 django-q2
+django-environ
 geopy
 gunicorn
 openpyxl

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -69,7 +69,14 @@
                         <li><a class="dropdown-item" href="{% url 'license' %}">{% translate "License" %}</a></li>
                         <li><a class="dropdown-item" href="{% url 'about' %}">{% translate "Contact" %}</a></li> <!-- about.html -->
                         <li><hr class="dropdown-divider"></li>
-                        <li><a class="dropdown-item" href="{% url 'logout' %}">{% translate "Log out" %}</a></li>
+                        <li>
+                            <form action="{% url 'logout' %}" method="post">
+                                {% csrf_token %}
+                                <button type="submit" class="dropdown-item">
+                                    {% translate "Log out" %}
+                                </button>
+                            </form>
+                        </li>
                     </ul>
                 </li>
 

--- a/app/templates/wefe/navbar.html
+++ b/app/templates/wefe/navbar.html
@@ -110,7 +110,14 @@
                         <!--li><a class="dropdown-item" href="{% url 'user_feedback' %}">{% translate "Feedback" %}</a></li-->
                         <li><a class="dropdown-item" href="{% url 'user_info' %}">{% translate "Account" %}</a></li> <!-- account.html -->
                         <li><hr class="dropdown-divider"></li>
-                        <li><a class="dropdown-item" href="{% url 'logout' %}">{% translate "Log out" %}</a></li>
+                        <li>
+                            <form action="{% url 'logout' %}" method="post">
+                                {% csrf_token %}
+                                <button type="submit" class="dropdown-item">
+                                    {% translate "Log out" %}
+                                </button>
+                            </form>
+                        </li>
                     </ul>
                 </li>
 

--- a/app/update_gui.sh
+++ b/app/update_gui.sh
@@ -1,6 +1,5 @@
 #!/usr/local/bin/python
 python manage.py compilemessages
-python manage.py makemigrations users projects dashboard && \
 python manage.py migrate && \
 python manage.py collectstatic && \
 echo 'Updated the WEFEgui app successfully!!'

--- a/app/wefe/helpers.py
+++ b/app/wefe/helpers.py
@@ -67,7 +67,6 @@ def get_renewables_output(proj_id, raw=True):
     if qs_ts.exists() is False:
         df, timeinfo = get_data(latitude=project.latitude, longitude=project.longitude, timeinfo=True)
 
-
         for col in df.columns:
             ts = Timeseries.objects.create(
                 name=col,
@@ -85,7 +84,7 @@ def get_renewables_output(proj_id, raw=True):
 
 class KoboHandler:
     base_survey_id = "aUTPpjLwttttNPF2tJgLKM"
-    request_headers = {"Accept": "application/json", "Authorization": "Token " + KOBO_API_TOKEN}
+    request_headers = {"Accept": "application/json", "Authorization": "Token " + str(KOBO_API_TOKEN)}
 
     def __init__(self, project):
         """When the class is initialized, a survey is cloned from the base survey, deployed and the permissions


### PR DESCRIPTION
- changed settings from OS environment variables to .env file, using django-environ. OS environment variables still work and take precedence over .env
  - env file: for me, now includes DEBUG, SQL_DATABASE, MVS_API_HOST, WEATHER_DATA_API, RN_API_TOKEN, EXCHANGE_RATES_API_TOKEN and USE_PROXY (since USE_PROXY is True by default?)
  - .env file has to be placed in app directory
- sqlite does not work as DB due to Timeseries, needs Postgres. Removed sqlite fallback from settings.
- libsass missing in pip requirements, added to dev_requirements
- logout did not work (needs POST in newer Django versions)
- added migrations to gitignore, since these are created during setup (see local_setup: `python manage.py makemigrations`). Not sure about translation texts (created with `python manage.py compilemessages` in setup as well), since there are already files committed to app/locale.
- use email config from settings in helpers instead of redefinition, move RenewableNinja config to settings