### PR TITLE
Fix online app 502 error

### DIFF
--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -84,6 +84,7 @@ if DEBUG is True:
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/app/requirements/postgres.txt
+++ b/app/requirements/postgres.txt
@@ -18,3 +18,4 @@ python-docx
 requests
 XlsxWriter
 datapackage
+whitenoise==6.9.0

--- a/app/requirements/postgres.txt
+++ b/app/requirements/postgres.txt
@@ -17,3 +17,4 @@ plotly
 python-docx
 requests
 XlsxWriter
+datapackage


### PR DESCRIPTION
- Whitenoise was missing to serve static files
- datapackage requirements was missing