### PR TITLE
Downgrade python version in production

### DIFF
--- a/app/compose/production/app_postgres/Dockerfile
+++ b/app/compose/production/app_postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.13
+FROM python:3.10
 
 RUN echo POSTGRES
 ENV APP_ROOT /src


### PR DESCRIPTION
The dependencies install for `oemof-tabular-plugins` was failing on build using python 3.11, so the python version is being downgraded to 3.10. 