### PR TITLE
Reduce workers to fix dash keyerrors

### DIFF
--- a/app/compose/production/app_postgres/start
+++ b/app/compose/production/app_postgres/start
@@ -9,4 +9,4 @@ python /src/manage.py migrate
 python /src/manage.py compilemessages
 #python /src/manage.py loaddata 'src/fixtures/fixture.json'
 echo $(ls -L 1 --dirsfirst)
-gunicorn epa.wsgi:application --bind 0.0.0.0:8000 --workers=4 --timeout=120
+gunicorn epa.wsgi:application --bind 0.0.0.0:8000 --workers=1 --timeout=120


### PR DESCRIPTION
Not ideal, but will work for now and considering the app will likely not have a ton of simultaneous users. See https://github.com/GibbsConsulting/django-plotly-dash/issues/85 for potential long-term solutions.