### PR TITLE
Fix/process survey

### DIFF
--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -593,6 +593,9 @@ class WEFEConfigurator:
         for name in unique_names:
             self.add_single_component(name)
 
+    def ensure_component(self, component):
+        return self.components.setdefault((component, component), {})
+
     def process_survey(self, survey):
         """
         Process the survey responses to build a nested structure. Some answers add components, while some change
@@ -662,10 +665,10 @@ class WEFEConfigurator:
                             if isinstance(component, list):
                                 # parallel components: add each one
                                 for subcomponent in component:
-                                    self.components[(subcomponent, subcomponent)] = {}
+                                    self.ensure_component(subcomponent)
                             else:
                                 # single sequential component
-                                self.components[(component, component)] = {}
+                                self.ensure_component(component)
 
                         # self.components.update({(component,component): {} for component in components_to_add})
                         self.wished_components[question_id] = other_answers
@@ -689,9 +692,8 @@ class WEFEConfigurator:
                                 target_components = self.mapping[parent_qid]["map_answer"][parent_answer]
 
                                 for target_component in target_components:
-                                    self.components[(target_component, target_component)].update(
-                                        {attribute_name: attribute_val}
-                                    )
+                                    comp = self.ensure_component(target_component)
+                                    comp[attribute_name] = attribute_val
                                     # some debugging for key error
                             except:
                                 print(f"There is a problem with question {question_id}")

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -594,6 +594,9 @@ class WEFEConfigurator:
             self.add_single_component(name)
 
     def ensure_component(self, component):
+        if not component or not str(component).strip():
+            logging.warning("Attempted to add empty component")
+            return None
         return self.components.setdefault((component, component), {})
 
     def process_survey(self, survey):
@@ -606,6 +609,8 @@ class WEFEConfigurator:
             "wind-turbine": {"capacity": 10, "some_parameter": 5},
             "diesel-generator": {"fuel_efficiency": 0.8}
         }
+        If numeric attributes are assigned multiple times, the values will not be added up but the maximum value of all
+        the assignments will be chosen instead.
 
         Additionally, certain answers defined in the 'criterias_list' are stored as class attributes 'self.criterias'
         to make them easily accessible.
@@ -693,8 +698,17 @@ class WEFEConfigurator:
 
                                 for target_component in target_components:
                                     comp = self.ensure_component(target_component)
-                                    comp[attribute_name] = attribute_val
-                                    # some debugging for key error
+                                    if comp is None:
+                                        continue
+
+                                    # If an already existing attribute of numeric type shall be assigned again, take the maximum value
+                                    if attribute_name in comp:
+                                        if isinstance(attribute_val, (int, float)):
+                                            comp[attribute_name] = max(comp[attribute_name], attribute_val)
+                                        else:
+                                            comp[attribute_name] = attribute_val
+                                    else:
+                                        comp[attribute_name] = attribute_val
                             except:
                                 print(f"There is a problem with question {question_id}")
                                 # import pdb;pdb.set_trace()


### PR DESCRIPTION
Make sure component assignments and attribute assignments are handled safely:
- do not add empty components
- ensure attributes are correctly added if the component itself has not been added yet (make survey processing independet of the order of answers)
- IMPORTANT NOTE regarding modelling: if an numeric attribute is assigned multiple times to the same component, the maximum value will be chosen instead of the sum. Example: The mapping architecture automatically adds an "inverter" component alongside "photovoltaics" and "battery", so if the user puts in 2kW of PV and 1kWh of battery storage, 2kW of inverter capacity will be added (instead of 3kW)