### PR TITLE
Simplify water treatment trains into pre-, core-, and post-treatment stages

### DIFF
--- a/app/wefe/helpers.py
+++ b/app/wefe/helpers.py
@@ -507,6 +507,47 @@ WATER_TREATMENT_TRAIN = {
         ["uv_disinfection", "chlorination"],  # both series/parallel possible
         "activated_carbon_filter",  # polishing
     ],
+    # Front-end treatment steps that prepare raw water for the main process.
+    # These units mainly remove coarse solids, grit, particles, and unstable feed characteristics
+    # so downstream treatment is protected from clogging, fouling, and performance loss.
+    "pre_treatment": [
+        "intake_structure",
+        "coarse_bar_screen",
+        "fine_screen",
+        "grit_chamber",
+        "cartridge_filter",
+        "simple_oxidation",
+        "coagulation_flocculation",
+    ],
+    # Main treatment steps that perform the primary water-quality transformation.
+    # These units are responsible for the core removal of dissolved contaminants, salts,
+    # pathogens, nutrients, organics, or other target pollutants.
+    "core_treatment": [
+        "slow_sand_filter",
+        "ceramic_filter",
+        "biofiltration",
+        "microfiltration",
+        "ultrafiltration",
+        "activated_carbon_filter",
+        "adsorption",
+        "ion_exchange",
+        "nanofiltration",
+        "electrodialysis",
+        "reverse_osmosis",
+        "membrane_distillation",
+        "distillation",
+        "boiling",
+        "photocatalysis",
+        "ozonation",
+        "biological_denitrification",
+    ],
+    # Final polishing and disinfection steps applied after the main treatment block.
+    # These units are used to ensure microbiological safety and improve final water quality
+    # before delivery to the drinking-water or service-water bus.
+    "post_treatment": [
+        "uv_disinfection",
+        "chlorination",
+    ],
     "pollutant_trains": {
         "drinking_water": {
             "decentralized": {

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -377,15 +377,15 @@ class WEFEConfigurator:
             merged_df = merged_df[ordered_cols]
 
             pre_treatment_df = merged_df[
-                (merged_df["type"].isin(water_treatment_train["pre_treatment"]))
+                (merged_df["type"].isin(WATER_TREATMENT_TRAIN["pre_treatment"]))
                 & (merged_df["name"].str.endswith("_1"))
             ]
             core_treatment_df = merged_df[
-                (merged_df["type"].isin(water_treatment_train["core_treatment"]))
+                (merged_df["type"].isin(WATER_TREATMENT_TRAIN["core_treatment"]))
                 & (merged_df["name"].str.endswith("_1"))
             ]
             post_treatment_df = merged_df[
-                (merged_df["type"].isin(water_treatment_train["post_treatment"]))
+                (merged_df["type"].isin(WATER_TREATMENT_TRAIN["post_treatment"]))
                 | (merged_df["name"].str.endswith("_2"))
             ]
             pre_treatment_df.to_csv(os.path.join(elements_dir, "water_pre_treatment.csv"), sep=";", index=False)
@@ -465,7 +465,7 @@ class WEFEConfigurator:
             resources = [r for r in resources if r["name"] not in old_water_treatment_csvs]
 
             for new_name, new_path in new_csv:
-                new_resource = copy.deepcopy(template)
+                new_resource = deepcopy(template)
                 new_resource["name"] = new_name
                 new_resource["path"] = f"data/elements/{new_path}"
 

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -410,7 +410,7 @@ class WEFEConfigurator:
             numeric_sum_cols = [
                 "capex",
                 "opex_fix",
-                "capacity_cost",
+                "annuity",
                 "specific_energy_consumption",
                 "land_requirement_factor",
                 "ghg_emission_factor",

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -394,6 +394,8 @@ class WEFEConfigurator:
 
             return merged_df
 
+        # TODO: Improve the aggregation/compression logic in the following function for each of the three water treatment sections.
+
         def aggregate_component_block(df, prefix, block_name, water_in_bus, water_out_bus):
             sub = df[df["name"].str.startswith(prefix)].copy()
 

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -329,18 +329,11 @@ class WEFEConfigurator:
 
         extra_bus_columns = ["brine_out_bus", "waste_biomass_out_bus", "N2_gas_bus"]
 
-        def modify_bus_csv():
+        def modify_bus_csv(has_sw):
             df_bus = pd.read_csv(bus_path, sep=";")
             df_bus = df_bus[~df_bus["name"].str.startswith(("DW_", "SW_"))]
 
             bus_names = ["DW_pre_treatment_out_bus", "DW_core_treatment_out_bus"]
-
-            has_sw = False
-
-            if os.path.exists(os.path.join(elements_dir, "water_treatment_without.csv")):
-                df_water_without = pd.read_csv(os.path.join(elements_dir, "water_treatment_without.csv"), sep=";")
-                if "name" in df_water_without.columns:
-                    has_sw = df_water_without["name"].str.startswith("SW_").any()
 
             if has_sw:
                 bus_names.extend(["SW_pre_treatment_out_bus", "SW_core_treatment_out_bus"])
@@ -352,6 +345,11 @@ class WEFEConfigurator:
             df_bus.to_csv(bus_path, sep=";", index=False)
 
         def modify_water_treatment(water_treatment_csvs, extra_cols):
+            has_sw_detected = False
+            if os.path.exists(os.path.join(elements_dir, "water_treatment_without.csv")):
+                df_water_without = pd.read_csv(os.path.join(elements_dir, "water_treatment_without.csv"), sep=";")
+                if "name" in df_water_without.columns:
+                    has_sw_detected = df_water_without["name"].str.startswith("SW_").any()
 
             dfs = []
             for csv_name in water_treatment_csvs:
@@ -367,7 +365,7 @@ class WEFEConfigurator:
 
             if not dfs:
                 print("No water treatment CSVs found.")
-                return None
+                return None, False
 
             merged_df = pd.concat(dfs, ignore_index=True, sort=False)
 
@@ -392,7 +390,7 @@ class WEFEConfigurator:
             core_treatment_df.to_csv(os.path.join(elements_dir, "water_core_treatment.csv"), sep=";", index=False)
             post_treatment_df.to_csv(os.path.join(elements_dir, "water_post_treatment.csv"), sep=";", index=False)
 
-            return merged_df
+            return merged_df, has_sw_detected
 
         # TODO: Improve the aggregation/compression logic in the following function for each of the three water treatment sections.
 
@@ -489,14 +487,14 @@ class WEFEConfigurator:
 
         # ---Main Logic & Function Calling---
 
-        merged_df = modify_water_treatment(original_water_treatment_csvs, extra_bus_columns)
+        merged_df, has_sw = modify_water_treatment(original_water_treatment_csvs, extra_bus_columns)
 
         # Exit simplification if no water treatment csvs are detected
         # Modification of bus csv and datapackage json is avoided
         if merged_df is None:
             return
 
-        modify_bus_csv()
+        modify_bus_csv(has_sw)
 
         water_csv_configs = [
             {

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -314,6 +314,45 @@ class WEFEConfigurator:
         add_excess()
         # ---------------------------------
 
+    def water_systems_simplification(self):
+
+        elements_dir = self.scenario_component_folder
+        dp_json_path = os.path.join(self.scenario_folder, "datapackage.json")
+        bus_path = os.path.join(elements_dir, "bus.csv")
+
+        original_water_treatment_csvs = [
+            "water_treatment_without.csv",
+            "water_treatment_with_brine.csv",
+            "water_treatment_with_biomass.csv",
+            "water_treatment_with_N2.csv",
+        ]
+
+        extra_bus_columns = ["brine_out_bus", "waste_biomass_out_bus", "N2_gas_bus"]
+
+        def modify_bus_csv():
+            df_bus = pd.read_csv(bus_path, sep=";")
+            df_bus = df_bus[~df_bus["name"].str.startswith(("DW_", "SW_"))]
+
+            bus_names = ["DW_pre_treatment_out_bus", "DW_core_treatment_out_bus"]
+
+            has_sw = False
+
+            if os.path.exists(os.path.join(elements_dir, "water_treatment_without.csv")):
+                df_water_without = pd.read_csv(os.path.join(elements_dir, "water_treatment_without.csv"), sep=";")
+                if "name" in df_water_without.columns:
+                    has_sw = df_water_without["name"].str.startswith("SW_").any()
+
+            if has_sw:
+                bus_names.extend(["SW_pre_treatment_out_bus", "SW_core_treatment_out_bus"])
+
+            simplified_buses = pd.DataFrame({"name": bus_names, "type": "bus", "balanced": True, "carrier": "water"})
+
+            df_bus = pd.concat([df_bus, simplified_buses], ignore_index=True)
+            df_bus = df_bus.drop_duplicates(subset=["name"], keep="last")
+            df_bus.to_csv(bus_path, sep=";", index=False)
+
+        modify_bus_csv()
+
     def waste_water_systems_postprocessing(self, survey):
 
         # Strip 'criteria_' from keys locally
@@ -1095,6 +1134,11 @@ if __name__ == "__main__":
 
     scenario = WEFEConfigurator(scen_id=scen_id, overwrite=False)
 
+    # Controls whether the water treatment system is simplified.
+    # True  -> run the simplification function and use the simplified setup.
+    # False -> skip simplification and keep the full treatment trains.
+    run_water_simplification = True  # default
+
     # Parse the survey to add components to a list
     scenario.process_survey(survey_answers)
 
@@ -1111,3 +1155,7 @@ if __name__ == "__main__":
     scenario.add_components()
     scenario.add_buses()
     scenario.add_sequences()
+
+    # Apply simplification only when the flag is enabled.
+    if run_water_simplification:
+        scenario.water_systems_simplification()

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -351,6 +351,56 @@ class WEFEConfigurator:
             df_bus = df_bus.drop_duplicates(subset=["name"], keep="last")
             df_bus.to_csv(bus_path, sep=";", index=False)
 
+        def modify_water_treatment(water_treatment_csvs, extra_cols):
+
+            dfs = []
+            for csv_name in water_treatment_csvs:
+                path = os.path.join(elements_dir, csv_name)
+                if os.path.exists(path):
+                    df = pd.read_csv(path, sep=";")
+                    dfs.append(df)
+                    try:
+                        os.remove(path)
+                        print(f"Deleted {csv_name}")
+                    except OSError as e:
+                        print(f"Could not delete {csv_name}: {e}")
+
+            if not dfs:
+                print("No water treatment CSVs found.")
+                return None
+
+            merged_df = pd.concat(dfs, ignore_index=True, sort=False)
+
+            common_cols = [col for col in merged_df.columns if col not in extra_cols]
+            ordered_cols = common_cols + [col for col in extra_cols if col in merged_df.columns]
+
+            merged_df = merged_df[ordered_cols]
+
+            pre_treatment_df = merged_df[
+                (merged_df["type"].isin(water_treatment_train["pre_treatment"]))
+                & (merged_df["name"].str.endswith("_1"))
+            ]
+            core_treatment_df = merged_df[
+                (merged_df["type"].isin(water_treatment_train["core_treatment"]))
+                & (merged_df["name"].str.endswith("_1"))
+            ]
+            post_treatment_df = merged_df[
+                (merged_df["type"].isin(water_treatment_train["post_treatment"]))
+                | (merged_df["name"].str.endswith("_2"))
+            ]
+            pre_treatment_df.to_csv(os.path.join(elements_dir, "water_pre_treatment.csv"), sep=";", index=False)
+            core_treatment_df.to_csv(os.path.join(elements_dir, "water_core_treatment.csv"), sep=";", index=False)
+            post_treatment_df.to_csv(os.path.join(elements_dir, "water_post_treatment.csv"), sep=";", index=False)
+
+            return merged_df
+
+        merged_df = modify_water_treatment(original_water_treatment_csvs, extra_bus_columns)
+
+        # Exit simplification if no water treatment csvs are detected
+        # Modification of bus csv and datapackage json is avoided
+        if merged_df is None:
+            return
+
         modify_bus_csv()
 
     def waste_water_systems_postprocessing(self, survey):

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -394,6 +394,59 @@ class WEFEConfigurator:
 
             return merged_df
 
+        def aggregate_component_block(df, prefix, block_name, water_in_bus, water_out_bus):
+            sub = df[df["name"].str.startswith(prefix)].copy()
+
+            if sub.empty:
+                return None
+
+            row = {}
+
+            row["name"] = f"{prefix}{block_name}"
+            row["type"] = f"water_{block_name}"
+            row["water_in_bus"] = water_in_bus
+            row["water_out_bus"] = water_out_bus
+
+            numeric_sum_cols = [
+                "capex",
+                "opex_fix",
+                "capacity_cost",
+                "specific_energy_consumption",
+                "land_requirement_factor",
+                "ghg_emission_factor",
+                "water_consumption_factor",
+            ]
+
+            for col in numeric_sum_cols:
+                if col in sub.columns:
+                    row[col] = sub[col].fillna(0).sum()
+
+            if "efficiency" in sub.columns:
+                eff = sub["efficiency"].dropna()
+                row["efficiency"] = eff.prod() if not eff.empty else None
+
+            if "lifetime" in sub.columns:
+                life = sub["lifetime"].dropna()
+                if not life.empty:
+                    if "capex" in sub.columns and sub["capex"].notna().any():
+                        weights = sub.loc[life.index, "capex"].fillna(0)
+                        if weights.sum() > 0:
+                            row["lifetime"] = (life * weights).sum() / weights.sum()
+                        else:
+                            row["lifetime"] = life.mean()
+                    else:
+                        row["lifetime"] = life.mean()
+
+            for col in sub.columns:
+                if col not in row:
+                    non_null = sub[col].dropna()
+                    row[col] = non_null.iloc[0] if not non_null.empty else None
+
+            row_df = pd.DataFrame([row])
+            row_df = row_df[[c for c in df.columns if c in row_df.columns]]  # reorder columns
+            row_df = row_df.dropna(axis=1, how="all")  # drop empty columns
+            return row_df
+
         def modify_data_package(water_treatment_csvs, extra_bus_columns):
 
             new_csv = [
@@ -442,6 +495,54 @@ class WEFEConfigurator:
             return
 
         modify_bus_csv()
+
+        water_csv_configs = [
+            {
+                "df": pd.read_csv(os.path.join(elements_dir, "water_pre_treatment.csv"), sep=";"),
+                "block_name": "pre_treatment",
+                "csv_name": "water_pre_treatment.csv",
+                "buses": {
+                    "DW_": ("untreated-water-bus", "DW_pre_treatment_out_bus"),
+                    "SW_": ("untreated-water-bus", "SW_pre_treatment_out_bus"),
+                },
+            },
+            {
+                "df": pd.read_csv(os.path.join(elements_dir, "water_core_treatment.csv"), sep=";"),
+                "block_name": "core_treatment",
+                "csv_name": "water_core_treatment.csv",
+                "buses": {
+                    "DW_": ("DW_pre_treatment_out_bus", "DW_core_treatment_out_bus"),
+                    "SW_": ("SW_pre_treatment_out_bus", "SW_core_treatment_out_bus"),
+                },
+            },
+            {
+                "df": pd.read_csv(os.path.join(elements_dir, "water_post_treatment.csv"), sep=";"),
+                "block_name": "post_treatment",
+                "csv_name": "water_post_treatment.csv",
+                "buses": {
+                    "DW_": ("DW_core_treatment_out_bus", "drinking-water-bus"),
+                    "SW_": ("SW_core_treatment_out_bus", "service-water-bus"),
+                },
+            },
+        ]
+
+        for config in water_csv_configs:
+            reduced_parts = []
+
+            for prefix, (water_in_bus, water_out_bus) in config["buses"].items():
+                reduced_df = aggregate_component_block(
+                    config["df"],
+                    prefix=prefix,
+                    block_name=config["block_name"],
+                    water_in_bus=water_in_bus,
+                    water_out_bus=water_out_bus,
+                )
+                if reduced_df is not None:
+                    reduced_parts.append(reduced_df)
+
+            if reduced_parts:
+                reduced_block_df = pd.concat(reduced_parts, ignore_index=True)
+                reduced_block_df.to_csv(os.path.join(elements_dir, config["csv_name"]), sep=";", index=False)
 
         modify_data_package(original_water_treatment_csvs, extra_bus_columns)
         # ---------------------------------

--- a/app/wefe/scenario_builder.py
+++ b/app/wefe/scenario_builder.py
@@ -394,6 +394,46 @@ class WEFEConfigurator:
 
             return merged_df
 
+        def modify_data_package(water_treatment_csvs, extra_bus_columns):
+
+            new_csv = [
+                ("water_pre_treatment", "water_pre_treatment.csv"),
+                ("water_core_treatment", "water_core_treatment.csv"),
+                ("water_post_treatment", "water_post_treatment.csv"),
+            ]
+
+            old_water_treatment_csvs = [f.removesuffix(".csv") for f in water_treatment_csvs]
+
+            with open(dp_json_path, "r", encoding="utf-8") as f:
+                datapackage = json.load(f)
+
+            resources = datapackage["resources"]
+            template = next(r for r in resources if r["name"] == "water_treatment_without")
+            resources = [r for r in resources if r["name"] not in old_water_treatment_csvs]
+
+            for new_name, new_path in new_csv:
+                new_resource = copy.deepcopy(template)
+                new_resource["name"] = new_name
+                new_resource["path"] = f"data/elements/{new_path}"
+
+                csv_cols = pd.read_csv(os.path.join(elements_dir, new_path), sep=";", nrows=0).columns.tolist()
+
+                for col in extra_bus_columns:
+                    if col in csv_cols:
+                        new_resource["schema"]["fields"].append({"name": col, "type": "string", "format": "default"})
+                        new_resource["schema"]["foreignKeys"].append(
+                            {"fields": col, "reference": {"resource": "bus", "fields": "name"}}
+                        )
+
+                resources.append(new_resource)
+
+            datapackage["resources"] = resources
+
+            with open(dp_json_path, "w", encoding="utf-8") as f:
+                json.dump(datapackage, f, indent=4, ensure_ascii=False)
+
+        # ---Main Logic & Function Calling---
+
         merged_df = modify_water_treatment(original_water_treatment_csvs, extra_bus_columns)
 
         # Exit simplification if no water treatment csvs are detected
@@ -402,6 +442,9 @@ class WEFEConfigurator:
             return
 
         modify_bus_csv()
+
+        modify_data_package(original_water_treatment_csvs, extra_bus_columns)
+        # ---------------------------------
 
     def waste_water_systems_postprocessing(self, survey):
 

--- a/app/wefe/views.py
+++ b/app/wefe/views.py
@@ -369,6 +369,12 @@ def request_wefesim_simulation(request, proj_id=None, default_datapackage="false
         wefe_conf.add_buses()
         wefe_conf.add_sequences()
 
+        run_water_simplification = True  # default
+
+        # Apply simplification only when the flag is enabled.
+        if run_water_simplification:
+            wefe_conf.water_systems_simplification()
+
         # Turn datapackage data and metadata into single json
         scenario_dir = Path(wefe_conf.scenario_folder)
         dp_export = export_single_json(scenario_dir, scenario_dir)


### PR DESCRIPTION
Simplification of water treatment trains into pre-, core-, and post-treatment stages to reduce simulation time. 

TODO: Make corresponding update in OTP, waiting for @MaaJoo13 to push his preprocessing changes to OTP production branch