### PR TITLE
Add validation and info boxes to survey fields

### DIFF
--- a/app/epa/settings.py
+++ b/app/epa/settings.py
@@ -161,7 +161,7 @@ LANGUAGE_CODE = "en"
 
 LOCALE_PATHS = (BASE_DIR / "locale",)
 
-LANGUAGES = [("de", "German"), ("en", "English")]
+LANGUAGES = [("en", "English")]
 
 TIME_ZONE = "Europe/Copenhagen"
 

--- a/app/templates/wefe/steps/survey_layout.html
+++ b/app/templates/wefe/steps/survey_layout.html
@@ -37,6 +37,11 @@
 										{% if field|is_matrix %}
 											{% comment %} here are the subquestion in matrix form {% endcomment %}
 											{{ field }}
+											{% for error in field.errors %}
+											<div class="row">
+												<p style="color:red"><b>{{ error }}</b></p>
+											</div>
+											{% endfor %}
 										{% else %}
 											<div class="form-group{% if field.errors %} invalid{% endif %}{% if field|is_subsubquestion %} subsubquestion{% endif %}{% if field|is_subquestion %} subquestion{% if field.initial %}{% else %} disabled {% endif %}{% endif %}">
 											{% if field.label|is_water_header %}

--- a/app/templates/wefe/steps/survey_layout.html
+++ b/app/templates/wefe/steps/survey_layout.html
@@ -29,7 +29,7 @@
 							</button>
 						</h3>
 
-						<div id="collapse-{{ forloop.counter }}" class="accordion-collapse collapse {% if forloop.first %}show{% endif %}" aria-labelledby="heading-{{ forloop.counter }}" data-bs-parent="#accordionQuestions">
+						<div id="collapse-{{ forloop.counter }}" class="accordion-collapse collapse {% if forloop.first %}show{% endif %} {% if cat in faulty_fields_cat %} show {% endif %}" aria-labelledby="heading-{{ forloop.counter }}" data-bs-parent="#accordionQuestions">
 							<div class="accordion-body cpn-business__questionnaire">
 								{% setvar False as matrix_current %}
 								{% for field in form %}

--- a/app/templates/wefe/steps/survey_layout.html
+++ b/app/templates/wefe/steps/survey_layout.html
@@ -17,7 +17,9 @@
 <section class="container-lg">
 	<div class="row">
 		<div class="col">
-			<p>Welcome to the survey</p>
+			<p><b>Note:</b> Information submitted under "other” will not be considered during modelling, and is only collected for future development.
+
+  </p>
 			<form id="surveyQuestions" action="{% url 'submit_survey' scen_id %}" method="POST">
 				{% csrf_token %}
 				<div class="container accordion" id="accordionQuestions">

--- a/app/wefe/forms.py
+++ b/app/wefe/forms.py
@@ -274,6 +274,7 @@ class SurveyQuestionForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
+        errors = {}
         if cleaned_data:
             subquestion_to_erase = []
             for record in cleaned_data:
@@ -341,6 +342,25 @@ class SurveyQuestionForm(forms.Form):
                     else:
                         if sq not in selected_subquestions:
                             subquestion_to_erase.append(sq)
+
+                # Perform field validation (check invalid input)
+                if question_id == "2":
+                    # subquestions to validate taken from WATER_SUPPLY_SURVEY_STRUCTURE
+                    if cleaned_data[record] == "No":
+                        sub_q_to_validate = ["3"]
+                    else:
+                        sub_q_to_validate = ["3a", "3b"]
+
+                    for q in sub_q_to_validate:
+                        subq_record = f"criteria_{q}"
+                        ans = cleaned_data[subq_record]
+                        if not ans or ans == ["other"]:
+                            errors[subq_record] = (
+                                'At least one of the provided sources must be selected, excluding "other".'
+                            )
+
+            for record, msg in errors.items():
+                self.add_error(record, msg)
 
         else:
             raise ValidationError("This form cannot be blank")

--- a/app/wefe/survey.py
+++ b/app/wefe/survey.py
@@ -237,7 +237,7 @@ COMPONENT_SURVEY_STRUCTURE = [
         "answer_map_to": TYPE_COMPONENT_ATTRIBUTE,
     },
     {
-        "question": "What ist the capacity [kW] of the installed wind power systems?",
+        "question": "What is the capacity [kW] of the installed wind power systems?",
         "question_id": "1.4",
         "variable_name": "capacity",
         "possible_answers": TYPE_FLOAT,
@@ -252,7 +252,7 @@ COMPONENT_SURVEY_STRUCTURE = [
         INFOBOX: "Hydropower is non-expandable and will not be optimized. Only existing capacity will be considered.",
     },
     {
-        "question": "What ist the capacity [kW] of the installed biogas plant?",
+        "question": "What is the capacity [kW] of the installed biogas plant?",
         "question_id": "1.6",
         "variable_name": "capacity",
         "possible_answers": TYPE_FLOAT,

--- a/app/wefe/survey.py
+++ b/app/wefe/survey.py
@@ -244,14 +244,15 @@ COMPONENT_SURVEY_STRUCTURE = [
         "answer_map_to": TYPE_COMPONENT_ATTRIBUTE,
     },
     {
-        "question": "What ist the capacity [kW] of the installed hydropower systems?",
+        "question": "What is the capacity [kW] of the installed hydropower systems?",
         "question_id": "1.5",
         "variable_name": "capacity",
         "possible_answers": TYPE_FLOAT,
         "answer_map_to": TYPE_COMPONENT_ATTRIBUTE,
+        INFOBOX: "Hydropower is non-expandable and will not be optimized. Only existing capacity will be considered.",
     },
     {
-        "question": "What ist the capacity [kW] of the installed biogas plant??",
+        "question": "What ist the capacity [kW] of the installed biogas plant?",
         "question_id": "1.6",
         "variable_name": "capacity",
         "possible_answers": TYPE_FLOAT,
@@ -373,6 +374,7 @@ WATER_SUPPLY_SURVEY_STRUCTURE = (
                     "variable_name": "capacity",
                     "possible_answers": TYPE_FLOAT,
                     "answer_map_to": TYPE_COMPONENT_ATTRIBUTE,
+                    INFOBOX: "Will only be used to calculate the throughput. If the throughput is given, this parameter will be ignored.",
                 },
                 {
                     "question": "What is the maximum throughput [m³/h] of the water pump",
@@ -519,6 +521,7 @@ WATER_SUPPLY_SURVEY_STRUCTURE = (
                 "question_id": "6",
                 "possible_answers": ["Yes", "No"],
                 "answer_map_to": TYPE_COMPONENT,
+                INFOBOX: "Currently not implemented in the simulation.",
             },
         ],
     )
@@ -589,6 +592,7 @@ CROPS_SURVEY_STRUCTURE = (
             "question_id": "8",
             "possible_answers": ["Yes", "No"],
             "subquestion": {"Yes": ["11", "9", "10"]},
+            INFOBOX: "Currently not implemented in the simulation.",
         }
     ]
     + generate_matrix_questions(

--- a/app/wefe/views.py
+++ b/app/wefe/views.py
@@ -556,6 +556,11 @@ def wefe_system_layout(request, proj_id, step_id=STEP_MAPPING["system_layout"]):
 
     page_information = "This survey will allow the user to build and simulate an energy system"
 
+    # Check which categories have field errors, so we can display them as open in the accordeon and the user can see the issue
+    faulty_fields = [k.replace("criteria_", "") for k in form.errors.keys()]
+    faulty_fields_cat = [SURVEY_CATEGORIES.get(q) for q in faulty_fields]
+    faulty_fields_cat = set(faulty_fields_cat)
+
     answer = render(
         request,
         "wefe/steps/survey_layout.html",
@@ -565,6 +570,7 @@ def wefe_system_layout(request, proj_id, step_id=STEP_MAPPING["system_layout"]):
             "categories_map": categories_map,
             "categories": categories,
             "categories_verbose": SURVEY_QUESTIONS_CATEGORIES,
+            "faulty_fields_cat": faulty_fields_cat,
             "matrix_headers": matrix_headers,
             "matrix_labels": matrix_labels,
             "proj_id": proj_id,

--- a/app/wefe/views.py
+++ b/app/wefe/views.py
@@ -485,7 +485,7 @@ def wefe_system_layout(request, proj_id, step_id=STEP_MAPPING["system_layout"]):
                 crit.value = json.dumps(value) if not isinstance(value, str) else value
                 crit.save(update_fields=["value"])
 
-        answer = HttpResponseRedirect(reverse("wefe_steps", args=[proj_id, step_id + 1]))
+            return HttpResponseRedirect(reverse("wefe_steps", args=[proj_id, step_id + 1]))
 
     else:
         if scen_id is None:
@@ -495,7 +495,7 @@ def wefe_system_layout(request, proj_id, step_id=STEP_MAPPING["system_layout"]):
             if last_scenario_id is None:
                 last_scenario_id = 0
             scenario_id = last_scenario_id + 1
-            answer = HttpResponseRedirect(reverse("view_survey", args=[scenario_id]))
+            return HttpResponseRedirect(reverse("view_survey", args=[scenario_id]))
         else:
             scenario_id = scen_id
 
@@ -526,52 +526,54 @@ def wefe_system_layout(request, proj_id, step_id=STEP_MAPPING["system_layout"]):
 
                 form = SurveyQuestionForm(qs=qs_answer)
 
-            categories = [cat for cat in SURVEY_QUESTIONS_CATEGORIES.keys()]
-            categories_map = []
-            matrix_headers = {}
-            matrix_labels = {}
-            for field in form.fields:
-                question_id = field.split("criteria_")[1]
-                # TODO: could be done from models "category" attribute
-                cat = SURVEY_CATEGORIES.get(question_id)
-                # TODO: reassign cat after testing phase is over
-                categories_map.append(cat)
-                # TODO here one can know that the question
-                if is_matrix_source(form.fields[field]):
-                    subs = []
-                    labels = []
-                    question = get_survey_question_by_id(SURVEY_STRUCTURE, question_id)
-                    for answer, subquestions in question["subquestion"].items():
-                        labels.append(answer)
-                        for sq_id in subquestions:
-                            q_main_id = ".".join(sq_id.split(".")[:2])
-                            subquestion = get_survey_question_by_id(SURVEY_STRUCTURE, sq_id)
-                            # print(subquestion)
-                            if subquestion.get("display_type", "") == "matrix":
-                                if subquestion["question"] not in subs:
-                                    subs.append(subquestion["question"])
-                    matrix_headers[field] = subs
-                    matrix_labels[field] = labels
-            page_information = "This survey will allow the user to build and simulate an energy system"
+    categories = [cat for cat in SURVEY_QUESTIONS_CATEGORIES.keys()]
+    categories_map = []
+    matrix_headers = {}
+    matrix_labels = {}
 
-            answer = render(
-                request,
-                "wefe/steps/survey_layout.html",
-                {
-                    "form": form,
-                    "scen_id": scenario_id,
-                    "categories_map": categories_map,
-                    "categories": categories,
-                    "categories_verbose": SURVEY_QUESTIONS_CATEGORIES,
-                    "matrix_headers": matrix_headers,
-                    "matrix_labels": matrix_labels,
-                    "proj_id": proj_id,
-                    "proj_name": project.name,
-                    "step_id": step_id,
-                    "step_list": WEFE_STEP_VERBOSE,
-                    "page_information": page_information,
-                },
-            )
+    for field in form.fields:
+        question_id = field.split("criteria_")[1]
+        # TODO: could be done from models "category" attribute
+        cat = SURVEY_CATEGORIES.get(question_id)
+        # TODO: reassign cat after testing phase is over
+        categories_map.append(cat)
+        # TODO here one can know that the question
+        if is_matrix_source(form.fields[field]):
+            subs = []
+            labels = []
+            question = get_survey_question_by_id(SURVEY_STRUCTURE, question_id)
+            for answer, subquestions in question["subquestion"].items():
+                labels.append(answer)
+                for sq_id in subquestions:
+                    q_main_id = ".".join(sq_id.split(".")[:2])
+                    subquestion = get_survey_question_by_id(SURVEY_STRUCTURE, sq_id)
+                    # print(subquestion)
+                    if subquestion.get("display_type", "") == "matrix":
+                        if subquestion["question"] not in subs:
+                            subs.append(subquestion["question"])
+            matrix_headers[field] = subs
+            matrix_labels[field] = labels
+
+    page_information = "This survey will allow the user to build and simulate an energy system"
+
+    answer = render(
+        request,
+        "wefe/steps/survey_layout.html",
+        {
+            "form": form,
+            "scen_id": scen_id,
+            "categories_map": categories_map,
+            "categories": categories,
+            "categories_verbose": SURVEY_QUESTIONS_CATEGORIES,
+            "matrix_headers": matrix_headers,
+            "matrix_labels": matrix_labels,
+            "proj_id": proj_id,
+            "proj_name": project.name,
+            "step_id": step_id,
+            "step_list": WEFE_STEP_VERBOSE,
+            "page_information": page_information,
+        },
+    )
 
     return answer
 


### PR DESCRIPTION
- Added the specific validation for the water questions, so that form will display an error if none or only "other" is selected
- Made sure that the accordion is not collapsed on page reload if there are errors in the fields (so the user can actually see where the problem is)
- Add info text to survey questions (to see updates locally, run `python manage.py update_survey_questions --update`
- Remove german as language

I did not implement the MOO description on step 5 as it seems you are not quite done defining what you want it to say. Have a look around these changes and let me know what you think. If you want to implement more validation you can also have a look at where and how it is implemented and do the same thing for whatever oder validation/info box you can think of.

I also updated the `otp` dependency to point to the default branch (production) although it doesn't really belong in this PR. That way it is done. 