### PR TITLE
Add summary of survey responses to demand page

### DIFF
--- a/app/templates/wefe/steps/demand.html
+++ b/app/templates/wefe/steps/demand.html
@@ -24,11 +24,6 @@
 		<h1>Demand collection survey</h1>
 		<p>To simulate demand timeseries using RAMP, first demand data should be collected. To create a shareable link
 			to a survey, please use the button below. </p>
-		<ul>
-			<li>What else should be possible here?</li>
-			<li>We could allow to host the survey on own server and input kobo API key from user</li>
-			<li>We could also allow to upload demand data directly, then we have give instructions into needed format</li>
-		</ul>
 		{% if not survey_id %}
 		<div>
 			<button id="survey_button" class="btn btn--medium" onclick="javascript:generateSurveyLink({{ proj_id }})" style="margin-top:0.5rem">
@@ -45,11 +40,22 @@
 		</div>
 		{% else %}
 		<div id="link_display">
-			Use the following link to fill out the questionnaire <a href="{{survey_url}}">{{ survey_url }} </a>
+			Use the following link to fill out the survey <a href="{{survey_url}}">{{ survey_url }} </a>
+		</div>
+		<br>
+		<div>
+			<h3>Current survey respondents:</h3>
+			<div style="display:flex;justify-content:space-between;max-width:50%">
+				<span>Local authority: {{ kobo_counts.respondent_local_aut }}</span>
+				<span>Service: {{ kobo_counts.respondent_service }}</span>
+				<span>Large scale farm: {{ kobo_counts.respondent_large_scale_farm }}</span>
+				<span>Business: {{ kobo_counts.respondent_business }}</span>
+			</div>
 		</div>
 		<div>
+			<br>
 		<button id="delete" class="btn btn--medium" onclick="javascript:deleteSurvey({{ proj_id }})" style="margin-top:0.5rem">
-			Delete survey (warning!!)
+			Delete survey
 		</button>
 		<span class="spinner" id="loading_spinner-delete" style="display:none; margin-top: 0.5rem">
 			<svg viewBox="25 25 50 50">
@@ -57,15 +63,13 @@
 			</svg>
 		</span>
 		</div>
-
-
 		{% endif %}
 	</section>
 </div>
-
 <div>
 	<section class="container-lg">
-		<h1>Test WEFE-Demand API</h1>
+		<hr>
+		<h1>Generate demand from survey answers</h1>
 		<button id="ramp-sim" class="btn btn--medium" onclick="javascript:wefeDemandRequest({{ proj_id }},default_survey=false)" style="margin-top:0.5rem">
 			Ramp simulation
 		</button>

--- a/app/templates/wefe/steps/demand.html
+++ b/app/templates/wefe/steps/demand.html
@@ -54,7 +54,7 @@
 		</div>
 		<div>
 			<br>
-		<button id="delete" class="btn btn--medium" onclick="javascript:deleteSurvey({{ proj_id }})" style="margin-top:0.5rem">
+		<button id="delete" class="btn btn--medium" onclick="return confirm('Are you sure? This will delete all submitted responses to the survey.') && deleteSurvey({{ proj_id }})" style="margin-top:0.5rem">
 			Delete survey
 		</button>
 		<span class="spinner" id="loading_spinner-delete" style="display:none; margin-top: 0.5rem">

--- a/app/wefe/helpers.py
+++ b/app/wefe/helpers.py
@@ -116,8 +116,42 @@ class KoboHandler:
         # self.assign_permissions("view_asset", "AnonymousUser")
         # self.project_survey_url = self.deploy_form()
 
-    def request_data(self, survey_id):
-        pass
+    def request_data(self, survey_id=None):
+        if survey_id is None:
+            survey_id = self.project_survey_id
+
+        response = requests.get(f"{KOBO_API_URL}/assets/{survey_id}/data", headers=self.request_headers, timeout=60)
+
+        return response.json()
+
+    def get_data_summary(self, survey_id=None):
+        if survey_id is None:
+            survey_id = self.project_survey_id
+
+        kobo_json = self.request_data(survey_id)
+
+        fields = [
+            "respondent_local_aut",
+            "respondent_service",
+            "respondent_large_scale_farm",
+            "respondent_business",
+        ]
+
+        counts = {field: 0 for field in fields} | {"respondent_unknown": 0}
+        nr_responses = kobo_json.get("count")
+        if nr_responses == 0:
+            return counts
+        else:
+            for record in kobo_json.get("results", []):
+                for field in fields:
+                    key = f"G_0/{field}"
+                    try:
+                        if record.get(key) == "yes":
+                            counts[field] += 1
+                    except KeyError:
+                        counts["respondent_unknown"] += 1
+
+        return counts
 
     def get_survey_metadata(self, survey_id=None):
         # TODO might be useful depending on how we need the surveys and what we save about them

--- a/app/wefe/views.py
+++ b/app/wefe/views.py
@@ -245,19 +245,11 @@ def wefe_demand(request, proj_id, step_id=STEP_MAPPING["demand"]):
         }
 
         if project.kobo_survey_id is not None:
-            context.update({"survey_id": project.kobo_survey_id, "survey_url": project.kobo_survey_url})
-
-        # if os.path.exists(output_path):
-        #     output_data = pd.read_csv(f"wefe/demand_data/{SURVEY_KEY}/.csv", index_col="datetime", decimal=",")
-        #     water_demand = output_data.loc[:, output_data.columns.str.contains("water")]
-        #     electricity_demand = output_data.loc[:, ~output_data.columns.str.contains("water")]
-        #     context.update(
-        #         {
-        #             "timestamps": scenario.get_timestamps(json_format=True),
-        #             "water_demand": water_demand.to_dict(orient="list"),
-        #             "electricity_demand": electricity_demand.to_dict(orient="list"),
-        #         }
-        #     )
+            kobo = KoboHandler(project)
+            counts = kobo.get_data_summary(kobo.project_survey_id)
+            context.update(
+                {"survey_id": project.kobo_survey_id, "survey_url": project.kobo_survey_url, "kobo_counts": counts}
+            )
 
         return render(request, "wefe/steps/demand.html", context)
 


### PR DESCRIPTION
Demand page now shows a summary with the count for each type of respondent (local auth/service/farmer/etc.)